### PR TITLE
use MathJax instead of KaTeX

### DIFF
--- a/sample/assets/template.html
+++ b/sample/assets/template.html
@@ -4,24 +4,21 @@
     <title>Problem Statement</title>
     <meta charset="utf-8">
     <link rel="stylesheet" type="text/css" href="./style.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.2/dist/katex.min.css"
-        integrity="sha384-yFRtMMDnQtDRO8rLpMIKrtPCD5jdktao2TV19YiZYWMDkUR5GQZR/NOVTdquEx1j" crossorigin="anonymous">
-    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.10.2/dist/katex.min.js"
-        integrity="sha384-9Nhn55MVVN0/4OFx7EE5kpFBPsEMZxKTCnA+4fqDmg12eCTqGi6+BB2LjY8brQxJ"
-        crossorigin="anonymous"></script>
-    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.10.2/dist/contrib/auto-render.min.js"
-        integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"
-        onload="renderMathInElement(document.body);"></script>
     <script>
-        document.addEventListener("DOMContentLoaded", function () {
-            renderMathInElement(
-                document.body, {
-                    delimiters: [
-                        { left: "$$", right: "$$", display: true },
-                        { left: "$", right: "$", display: false }],
-                    ignoredTags: [],
-                })
-        });
+      MathJax = {
+          options: {
+              processHtmlClass: 'input-format|language-input-format'
+          },
+          chtml: {
+              matchFontHeight: false
+          },
+          tex: {
+              inlineMath: [['$', '$']]
+          }
+      };
+    </script>
+    <script id="MathJax-script" async
+            src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js">
     </script>
   </head>
   <body>

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         "google-api-python-client",
         "google-auth-httplib2",
         "google-auth-oauthlib",
-        "markdown",
+        "markdown>=3.1.0",
         "jinja2",
         "toml",
         "colorlog",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         "google-api-python-client",
         "google-auth-httplib2",
         "google-auth-oauthlib",
-        "markdown>=3.1.0",
+        "markdown>=3.3.1",
         "jinja2",
         "toml",
         "colorlog",

--- a/statements_manager/src/manager/base_manager.py
+++ b/statements_manager/src/manager/base_manager.py
@@ -21,9 +21,9 @@ class ReplaceSampleFormatExpr(Preprocessor):
         new_lines = []
         for line in lines:
             if line.strip().startswith("```"):
-                match = (line.strip() == "```")
+                match = line.strip() == "```"
                 if match and cnt_all % 2 == 0:
-                    new_lines.append('``` { .input-format .input-format }')
+                    new_lines.append("``` { .input-format .input-format }")
                 else:
                     new_lines.append(line)
                 cnt_all += 1
@@ -35,7 +35,9 @@ class ReplaceSampleFormatExpr(Preprocessor):
 
 class ReplaceSampleFormatExprExtension(Extension):
     def extendMarkdown(self, md):
-        md.preprocessors.register(ReplaceSampleFormatExpr(md), "replace_sample_format", 999)
+        md.preprocessors.register(
+            ReplaceSampleFormatExpr(md), "replace_sample_format", 999
+        )
 
 
 class BaseManager:


### PR DESCRIPTION
closes #24 

- MathJax をテンプレートに入れ、KaTeX をテンプレートから削除
- ```` ``` ```` を置換するような `markdown` 用拡張機能を定義
- `<pre><code>` 内の数式もレンダリングされるように設定