### PR TITLE
#75 除外するサンプルファイルの指定についてワイルドカードを使用可能にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ ss-manager reg-creds WORKING_DIR CREDS_PATH
 - `ignore_samples` (任意)
   - `sample_path` で指定されたディレクトリにある、サンプルケースとして認識されるファイル名のうち、問題文に反映してほしくないものをリスト形式で指定します。拡張子は含めてはなりません
   - 例えば `00_sample_00` および `00_sample_hoge` を問題文に含めてほしくない場合、`ignore_samples = ["00_sample_00", "00_sample_hoge"]` のように設定します
+  - [Unix のシェル形式のワイルドカード](https://docs.python.org/ja/3/library/fnmatch.html) に対応しています
   - 何も指定されなかった場合、見つかった全てのサンプルケースが問題文に反映されます
 - `params_path` (任意)
   - 問題制約となるパラメータの値を、generator や validator で利用できるようにファイルに出力したいときに、パラメータを記載したファイルの出力パスを指定します

--- a/statements_manager/src/variables_converter.py
+++ b/statements_manager/src/variables_converter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import fnmatch
 import math
 import pathlib
 from logging import Logger, getLogger
@@ -136,8 +137,13 @@ class SamplesConverter:
             if str(exp_filename).lower().find("sample") >= 0:
                 sample_names.add(exp_filename.stem)
 
-        sample_names -= ignore_samples
-        return sorted(list(sample_names))
+        filtered_sample = list()
+        for sample_name in sample_names:
+            if not any(
+                [fnmatch.fnmatch(sample_name, pattern) for pattern in ignore_samples]
+            ):
+                filtered_sample.append(sample_name)
+        return sorted(filtered_sample)
 
     def print_warning(
         self,
@@ -179,7 +185,7 @@ class SamplesConverter:
             problem_attr["sample_path"],
             problem_attr["statement_path"],
             problem_attr["lang"],
-            set(problem_attr.get("ignore_samples", list())),
+            problem_attr.get("ignore_samples", list()),
         )
         if len(sample_names) == 0:
             logger.warning("samples are not set")


### PR DESCRIPTION
## 概要

- ワイルドカードで指定できると逐一リストを更新する必要が無くなりそうで嬉しそう
- `fnmatch` を使って対応