### PR TITLE
#84 元の文章と提案の両方が表示される

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ dev =
     mypy
 
 [flake8]
-max-line-length = 88
+max-line-length = 100
 
 [mypy]
 

--- a/statements_manager/src/manager/docs_manager.py
+++ b/statements_manager/src/manager/docs_manager.py
@@ -1,4 +1,5 @@
 import pathlib
+import pprint
 from logging import Logger, getLogger
 
 from googleapiclient.discovery import build
@@ -38,5 +39,13 @@ class DocsManager(BaseManager):
             if "paragraph" not in content:
                 continue
             for element in content["paragraph"]["elements"]:
-                text += element["textRun"]["content"]
+                statement = element["textRun"]["content"]
+                if "suggestedInsertionIds" not in element["textRun"]:
+                    text += statement
+                else:
+                    logger.warning(
+                        f"proposed element for addition (ignored in rendering): {statement}"
+                    )
+                if "suggestedDeletionIds" in element["textRun"]:
+                    logger.warning(f"proposed element for deletion: {statement}")
         return text

--- a/statements_manager/src/manager/docs_manager.py
+++ b/statements_manager/src/manager/docs_manager.py
@@ -1,5 +1,4 @@
 import pathlib
-import pprint
 from logging import Logger, getLogger
 
 from googleapiclient.discovery import build


### PR DESCRIPTION
## 概要

- 元の文章と追加/修正/削除の提案の両方がレンダリングの対象になっていたため、提案前のバージョンがレンダリングされるよう修正
  - 提案は「追加」と「削除」からなるが、このうち「追加」はレンダリングの対象から外した
- 「追加」および「削除」の提案が残っている場合は、warning でその存在を伝えるようにした