### PR TITLE
PDF の設定を `problemset.toml` に書けるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ ss-manager reg-creds WORKING_DIR CREDS_PATH
 
 `problemset.toml` は、`ss-manager run` を実行するときの `WORKING_DIR` の階層と一致しているときにのみ参照されます。
 
-- `[template]`
+- `[template]`: テンプレートファイルの設定
   - `template_path`
     - HTML および PDF 出力で使用されるテンプレート HTML へのパスを指定します (指定されていない場合、デフォルトのテンプレートが適用されます)
     - テンプレートでは、問題文本文に相当する部分に `{@problem.statement}` 文を記述する必要があります。詳細は `sample/templates/default.html` などをご覧ください
@@ -193,6 +193,13 @@ ss-manager reg-creds WORKING_DIR CREDS_PATH
   - `postprocess_path`
     - HTML ファイルに関して後処理を行う **Python スクリプト** へのパスを指定します。HTML 形式にレンダリングされた後に適用したい処理を記述してください (指定されていない場合、後処理は行われません)
     - HTML ファイルの中身は標準入力で与えられ、後処理の結果は標準出力で返す必要があります。詳細は `sample/templates/icpc_domestic/postprocess.py` をご覧ください
+- `[pdf]`: PDF 出力時の [wkhtmltopdf](https://wkhtmltopdf.org/) (PDF にレンダリングする際に使用されるサードパーティライブラリ) の設定
+  - `[pdf.common]`
+    - 各問題のファイルにも、問題セットのファイルにも適用されてほしい設定をここに記載します
+  - `[pdf.problem]`
+    - 各問題のファイルにのみ適用されてほしい設定をここに記載します
+  - `[pdf.problemset]`
+    - 問題セットのファイルにのみ適用されてほしい設定をここに記載します
 
 ### 6. ファイルを HTML / PDF / Markdown 化する
 

--- a/sample/problemset.toml
+++ b/sample/problemset.toml
@@ -4,6 +4,11 @@
     postprocess_path = "./templates/icpc_domestic/postprocess.py"
 
 [pdf]
+    [pdf.common]
+        margin-top = 10
+        margin-right = 10
+        margin-bottom = 10
+        margin-left = 10
     [pdf.problem]
         javascript-delay = 1000
     [pdf.problemset]

--- a/sample/problemset.toml
+++ b/sample/problemset.toml
@@ -2,3 +2,9 @@
     template_path = "./templates/icpc_domestic/template.html"
     preprocess_path = "./templates/icpc_domestic/preprocess.py"
     postprocess_path = "./templates/icpc_domestic/postprocess.py"
+
+[pdf]
+    [pdf.problem]
+        javascript-delay = 1000
+    [pdf.problemset]
+        javascript-delay = 10000

--- a/statements_manager/src/project.py
+++ b/statements_manager/src/project.py
@@ -23,9 +23,11 @@ class Project:
         self._check_project()
         self.template_attr = self._search_template_attr()
         self._check_template()
+        self.pdf_attr_raw = self._search_pdf_attr_raw()
         self.stmts_manager = Manager(
             problem_attr=self.problem_attr,
             template_attr=self.template_attr,
+            pdf_attr_raw=self.pdf_attr_raw,
         )
 
     def run_problems(self, make_problemset: bool) -> None:
@@ -235,3 +237,20 @@ class Project:
             if key in config_dict.keys():
                 result_dict[key] = dir_name / config_dict[key]
         return result_dict
+
+    def _search_pdf_attr_raw(
+        self,
+    ) -> dict[str, Any]:
+        """problemset.toml (問題セットの設定ファイル) を探し、PDF 設定を得る"""
+        config_file = self._cwd / "problemset.toml"
+        if config_file.exists():
+            config_toml = toml.load(config_file)
+            if "pdf" in config_toml:
+                config_dict = config_toml["pdf"]
+            else:
+                logger.warning("pdf settings not found.")
+                config_dict = {}
+        else:
+            logger.warning(f"{config_file} not found.")
+            config_dict = {}
+        return config_dict


### PR DESCRIPTION
## 概要

- PDF の設定がハードコーディング (ユーザー側から設定できない) されていて、数式のレンダリングにかける時間の調整・PDF のスタイル調整が不可能で良くない
- これを `problemset.toml` に記載できるようにした
