### PR TITLE
credentials をホームディレクトリ上の隠しディレクトリに保存する

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,12 @@ pip install statements-manager
 
 ![Screenshot from 2021-08-19 23-25-11](https://user-images.githubusercontent.com/19629946/130088501-5e1208df-445a-4797-be31-60a77f04c91d.png)
 
-- 以下のコマンドを打って、JSON ファイルを作業ディレクトリに登録します
-  - `WORKING_DIR` とは、"How to use" の冒頭にあるように、各問題ディレクトリの 1 つ上の階層です
+- 以下のコマンドを打って、JSON ファイルを登録します
   - 登録が終われば、`CREDS_PATH` にある json ファイルは削除しても構いません
+  - JSON ファイルは、ホームディレクトリに生成される隠しフォルダ `.ss-manager` の中に格納されます
 
 ```python
-ss-manager reg-creds WORKING_DIR CREDS_PATH
+ss-manager reg-creds CREDS_PATH
 ```
 
 ### 3. 問題ごとに設定ファイル `problem.toml` を作る

--- a/statements_manager/src/utils.py
+++ b/statements_manager/src/utils.py
@@ -1,6 +1,6 @@
 import pickle
 from pathlib import Path
-from typing import Any, Tuple, Union
+from typing import Any, Union
 
 from google.auth.transport.requests import Request
 from google_auth_oauthlib.flow import InstalledAppFlow
@@ -24,13 +24,13 @@ def ask_ok(question: str, default_response: bool = True) -> bool:
     return response in ["y", "ye", "yes"]
 
 
-def create_token(
-    creds_path: str, token_path: Union[str, None] = None
-) -> Tuple[Any, Any]:
+def create_token(creds_path: str, token_path: Union[str, None] = None) -> Any:
     scopes = ["https://www.googleapis.com/auth/documents.readonly"]
-    token_obj = None
+    if not Path(creds_path).exists():
+        return None
 
     # set credentials
+    token_obj = None
     if token_path and Path(token_path).exists():
         with open(token_path, "rb") as token:
             token_obj = pickle.load(token)


### PR DESCRIPTION
## 概要

- 今までの実装では、`ss-mangaer reg-creds` で保存された credentials は `WORKING_DIR` が一致していないと使えず不便であった
- `ss-manager reg-creds` するときに、ホームディレクトリ上の隠しディレクトリ中に保存するようにし、常にそれを参照するように変更した
  - 今までのバージョンと互換性を持たせるために、`WORKING_DIR` の中にある credentials も引き続き使用可能である。どちらかの credentials が有効であれば正常に docs の文章を読み込むことができる。