### PR TITLE
サンプル入出力の形式をテンプレートで指定可能にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,9 @@ ss-manager reg-creds CREDS_PATH
   - `template_path`
     - HTML および PDF 出力で使用されるテンプレート HTML へのパスを指定します (指定されていない場合、デフォルトのテンプレートが適用されます)
     - テンプレートでは、問題文本文に相当する部分に `{@problem.statement}` 文を記述する必要があります。詳細は `sample/templates/default.html` などをご覧ください
+  - `sample_template_path`
+    - 入出力例の部分に使われるテンプレート HTML へのパスを指定します (指定されていない場合、デフォルトのテンプレートが適用されます)
+    - テンプレートの書き方は `sample/templates/sample_default.html` などをご覧ください
   - `preprocess_path`
     - Markdown ファイルに関して前処理を行う **Python スクリプト** へのパスを指定します。Markdown が HTML 形式にレンダリングされる前に適用したい処理を記述してください (指定されていない場合、前処理は行われません)
     - Markdown ファイルの中身は標準入力で与えられ、前処理の結果は標準出力で返す必要があります。詳細は `sample/templates/icpc_domestic/preprocess.py` をご覧ください

--- a/sample/I/tests/00_sample_00.md
+++ b/sample/I/tests/00_sample_00.md
@@ -1,10 +1,42 @@
-|標準入力|標準出力|
-|---|---|
-|```3```| |
-| |```? 1 2```|
-|```2```| |
-| |```? 2 3```|
-|```1```| |
-| |```? 1 3```|
-|```1```||
-| |```! 2 3 1```|
+<table>
+    <thead>
+        <tr>
+            <td>標準入力</td>
+            <td>標準出力</td>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><pre>3</pre></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td></td>
+            <td><pre>? 1 2</pre></td>
+        </tr>
+        <tr>
+            <td><pre>2</pre></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td></td>
+            <td><pre>? 2 3</pre></td>
+        </tr>
+        <tr>
+            <td><pre>1</pre></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td></td>
+            <td><pre>? 1 3</pre></td>
+        </tr>
+        <tr>
+            <td><pre>1</pre></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td></td>
+            <td><pre>! 2 3 1</pre></td>
+        </tr>
+    </tbody>
+</table>

--- a/sample/problemset.toml
+++ b/sample/problemset.toml
@@ -1,5 +1,6 @@
 [template]
     template_path = "./templates/icpc_domestic/template.html"
+    sample_template_path = "./templates/sample_default.html"
     preprocess_path = "./templates/icpc_domestic/preprocess.py"
     postprocess_path = "./templates/icpc_domestic/postprocess.py"
 

--- a/sample/templates/sample_default.html
+++ b/sample/templates/sample_default.html
@@ -1,0 +1,17 @@
+{% if sample_data.input_text is defined %}
+    <h3>{% if sample_data.language == "ja" %}入力例{% elif sample_data.language == "en" %}Sample Input{% endif %} {% if sample_data.do_numbering %}{{ sample_data.i_sample }}{% endif %}</h3>
+    <pre>{{ sample_data.input_text }}</pre>
+{% endif %}
+
+{% if sample_data.output_text is defined %}
+    <h3>{% if sample_data.language == "ja" %}出力例{% elif sample_data.language == "en" %}Sample Output{% endif %} {% if sample_data.do_numbering %}{{ sample_data.i_sample }}{% endif %}</h3>
+    <pre>{{ sample_data.output_text }}</pre>
+{% endif %}
+
+{% if sample_data.md_text is defined %}
+{{ sample_data.md_text }}
+{% endif %}
+
+{% if sample_data.explanation_text is defined %}
+{{ sample_data.explanation_text }}
+{% endif %}

--- a/statements_manager/main.py
+++ b/statements_manager/main.py
@@ -7,7 +7,7 @@ from logging import Logger, basicConfig, getLogger
 from statements_manager.src.project import Project
 from statements_manager.src.utils import ask_ok, create_token
 
-logger = getLogger(__name__)  # type: Logger
+logger: Logger = getLogger(__name__)
 
 
 def set_logger(debug_mode: bool) -> None:

--- a/statements_manager/src/manager.py
+++ b/statements_manager/src/manager.py
@@ -12,7 +12,11 @@ from googleapiclient.discovery import build
 from statements_manager.src.params_maker.lang_to_class import lang_to_class
 from statements_manager.src.renderer import Renderer
 from statements_manager.src.utils import create_token
-from statements_manager.template import default_template_html, template_pdf_options
+from statements_manager.template import (
+    default_sample_template_html,
+    default_template_html,
+    template_pdf_options,
+)
 
 logger = getLogger(__name__)  # type: Logger
 
@@ -33,6 +37,7 @@ class Manager:
         self.pdf_attr_raw = pdf_attr_raw  # type: dict[str, Any]
         self.renderer = Renderer(
             template_attr.get("template_html", default_template_html),
+            template_attr.get("sample_template_html", default_sample_template_html),
             template_attr.get("preprocess_path", None),
             template_attr.get("postprocess_path", None),
         )
@@ -227,10 +232,6 @@ class Manager:
 
             # 問題文取得
             valid_problem_ids.append(problem_id)
-            raw_statement = self.renderer.replace_vars(
-                problem_attr=self.problem_attr[problem_id],
-                statement_str=raw_statement,
-            )
             self.problem_attr[problem_id]["raw_statement"] = raw_statement
 
             # パラメータファイル作成

--- a/statements_manager/src/manager.py
+++ b/statements_manager/src/manager.py
@@ -18,7 +18,7 @@ from statements_manager.template import (
     template_pdf_options,
 )
 
-logger = getLogger(__name__)  # type: Logger
+logger: Logger = getLogger(__name__)
 
 
 class ContentsStatus(Enum):
@@ -33,8 +33,8 @@ class Manager:
         pdf_attr_raw: dict[str, Any],
     ):
         self._cwd = Path.cwd()
-        self.problem_attr = problem_attr  # type: dict[str, Any]
-        self.pdf_attr_raw = pdf_attr_raw  # type: dict[str, Any]
+        self.problem_attr: dict[str, Any] = problem_attr
+        self.pdf_attr_raw: dict[str, Any] = pdf_attr_raw
         self.renderer = Renderer(
             template_attr.get("template_html", default_template_html),
             template_attr.get("sample_template_html", default_sample_template_html),
@@ -126,12 +126,12 @@ class Manager:
             "params_path" in self.problem_attr[problem_id]
             and "constraints" in self.problem_attr[problem_id]
         ):
-            ext = Path(self.problem_attr[problem_id]["params_path"]).suffix  # type: str
+            ext: str = Path(self.problem_attr[problem_id]["params_path"]).suffix
             if ext in lang_to_class:
                 params_maker = lang_to_class[ext](
                     self.problem_attr[problem_id]["constraints"],
                     self.problem_attr[problem_id]["params_path"],
-                )  # type: Any
+                )
                 params_maker.run()
             else:
                 logger.warning(

--- a/statements_manager/src/params_maker/lang_to_class.py
+++ b/statements_manager/src/params_maker/lang_to_class.py
@@ -4,9 +4,9 @@ from typing import Any
 
 from statements_manager.src.params_maker.languages.cplusplus import CppParamsMaker
 
-lang_to_class = {
+lang_to_class: dict[str, Any] = {
     ".cpp": CppParamsMaker,
     ".cc": CppParamsMaker,
     ".hpp": CppParamsMaker,
     ".h": CppParamsMaker,
-}  # type: dict[str, Any]
+}

--- a/statements_manager/src/params_maker/params_maker.py
+++ b/statements_manager/src/params_maker/params_maker.py
@@ -4,7 +4,7 @@ from abc import abstractmethod
 from logging import Logger, getLogger
 from typing import Any
 
-logger = getLogger(__name__)  # type: Logger
+logger: Logger = getLogger(__name__)
 
 
 class ParamsMaker:
@@ -13,7 +13,7 @@ class ParamsMaker:
         self.output_path = output_path
 
     def run(self) -> None:
-        params_lines = []  # type: list[str]
+        params_lines: list[str] = []
         params_lines.append(self.header())
         for key, value in self.params.items():
             if not all(ord(c) < 128 for c in str(value)):

--- a/statements_manager/src/project.py
+++ b/statements_manager/src/project.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 from logging import Logger, getLogger
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any
 
 import toml
 
@@ -11,13 +11,13 @@ from statements_manager.src.manager import Manager
 from statements_manager.src.recognize_mode import recognize_mode
 from statements_manager.src.utils import resolve_path
 
-logger = getLogger(__name__)  # type: Logger
+logger: Logger = getLogger(__name__)
 
 
 class Project:
     def __init__(self, working_dir: str, ext: str) -> None:
-        self._cwd = Path(working_dir).resolve()
-        self._ext = ext  # type: str
+        self._cwd: Path = Path(working_dir).resolve()
+        self._ext: str = ext
         self.problem_attr = self._search_problem_attr()
         self._check_project()
         self.template_attr = self._search_template_attr()
@@ -31,7 +31,7 @@ class Project:
 
     def run_problems(self, make_problemset: bool) -> None:
         """問題文作成を実行する"""
-        problem_ids = sorted(list(self.problem_attr.keys()))  # type: List[str]
+        problem_ids: list[str] = sorted(list(self.problem_attr.keys()))
         self.stmts_manager.run(
             problem_ids=problem_ids,
             output_ext=self._ext,
@@ -125,7 +125,7 @@ class Project:
         問題ごとに設定ファイルを読み込む
         """
         ids = set()
-        result_dict = {}  # type: dict[str, Any]
+        result_dict: dict[str, Any] = {}
         for problem_file in sorted(self._cwd.glob("./**/problem.toml")):
             dir_name = problem_file.parent.resolve()
             problem_dict = toml.load(problem_file)
@@ -142,8 +142,8 @@ class Project:
 
             # statements で設定されているものそれぞれについて回す
             # id と、どの lang が何回来たかに応じてファイル名が決定
-            lang_count = {}  # type: dict[str, int]
-            lang_number = {}  # type: dict[str, int]
+            lang_count: dict[str, int] = {}
+            lang_number: dict[str, int] = {}
             for statement_info in problem_dict["statements"]:
                 lang = statement_info.get("lang", "en")
                 lang_number.setdefault(lang, 0)
@@ -223,7 +223,7 @@ class Project:
             logger.warning(f"{config_file} not found.")
             config_dict = {}
 
-        result_dict = {}  # type: Dict[str, Any]
+        result_dict: dict[str, Any] = {}
         # テンプレートファイル
         if "template_path" in config_dict:
             with open(dir_name / Path(config_dict["template_path"])) as f:

--- a/statements_manager/src/project.py
+++ b/statements_manager/src/project.py
@@ -10,7 +10,6 @@ import toml
 from statements_manager.src.manager import Manager
 from statements_manager.src.recognize_mode import recognize_mode
 from statements_manager.src.utils import resolve_path
-from statements_manager.template import default_template_html
 
 logger = getLogger(__name__)  # type: Logger
 
@@ -72,6 +71,7 @@ class Project:
             "postprocess_path",
             # これ以下はユーザーが設定しない属性
             "template_html",
+            "sample_template_html",
             "output_path",
         ]
         for key in self.template_attr.keys():
@@ -228,8 +228,9 @@ class Project:
         if "template_path" in config_dict:
             with open(dir_name / Path(config_dict["template_path"])) as f:
                 result_dict["template_html"] = f.read()
-        else:
-            result_dict["template_html"] = default_template_html
+        if "sample_template_path" in config_dict:
+            with open(dir_name / Path(config_dict["sample_template_path"])) as f:
+                result_dict["sample_template_html"] = f.read()
 
         result_dict["output_path"] = dir_name / "problemset"
         keys = ["preprocess_path", "postprocess_path"]

--- a/statements_manager/src/recognize_mode.py
+++ b/statements_manager/src/recognize_mode.py
@@ -5,7 +5,7 @@ from logging import Logger, getLogger
 from typing import Any
 from urllib.parse import urlparse
 
-logger = getLogger(__name__)  # type: Logger
+logger: Logger = getLogger(__name__)
 
 
 def is_valid_url(url: str) -> bool:

--- a/statements_manager/src/variables_converter.py
+++ b/statements_manager/src/variables_converter.py
@@ -4,11 +4,11 @@ import fnmatch
 import math
 import pathlib
 from logging import Logger, getLogger
-from typing import Any, List, Set
+from typing import Any, Set
 
 from jinja2 import DictLoader, Environment
 
-logger = getLogger(__name__)  # type: Logger
+logger: Logger = getLogger(__name__)
 
 
 def to_string(value: Any) -> str:
@@ -75,7 +75,7 @@ class SamplesConverter:
         statement_path: pathlib.Path,
         language: str,
         ignore_samples: Set,
-    ) -> List[str]:
+    ) -> list[str]:
         # sample_path 以下で、ファイル名に 'sample' を含むものはサンプルであるとする
         sample_names = set()
         for in_filename in sample_path.glob("./*.in"):
@@ -195,9 +195,9 @@ class SamplesConverter:
 
 class VariablesConverter:
     def __init__(self, problem_attr: dict[str, Any], sample_template: str) -> None:
-        self.vars = {}  # type: dict[str, Any]
-        self.vars["constraints"] = {}  # dict[str, str]
-        self.vars["samples"] = {}  # dict[str, str]
+        self.vars: dict[str, Any] = {}
+        self.vars["constraints"] = {}
+        self.vars["samples"] = {}
         self.constraints_converter = ConstraintsConverter()
         self.samples_converter = SamplesConverter()
 

--- a/statements_manager/src/variables_converter.py
+++ b/statements_manager/src/variables_converter.py
@@ -6,6 +6,8 @@ import pathlib
 from logging import Logger, getLogger
 from typing import Any, List, Set
 
+from jinja2 import DictLoader, Environment
+
 logger = getLogger(__name__)  # type: Logger
 
 
@@ -27,33 +29,10 @@ def to_string(value: Any) -> str:
         return str(value)
 
 
-class NaturalLanguage:
-    HEADER_MD = "### "
-
-    def __init__(self, lang: str) -> None:
-        if lang == "ja":
-            self.language = "ja"
-        elif lang == "en":
-            self.language = "en"
-        else:
-            logger.error(f"unknown lang: '{lang}'")
-            raise ValueError(f"unknown lang: '{lang}'")
-
-    def lang(self) -> str:
-        return self.language
-
-    def header_input(self) -> str:
-        if self.language == "ja":
-            return self.HEADER_MD + "入力例"
-        elif self.language == "en":
-            return self.HEADER_MD + "Sample Input"
-        return ""
-
-    def header_output(self) -> str:
-        if self.language == "ja":
-            return self.HEADER_MD + "出力例"
-        elif self.language == "en":
-            return self.HEADER_MD + "Output for the Sample Input"
+def fetch_text(path: pathlib.Path) -> str:
+    try:
+        return open(path).read()
+    except OSError:
         return ""
 
 
@@ -87,25 +66,6 @@ class SampleFile:
         with open(self.filename, "r") as f:
             contents = f.read() + "\n"
             return contents
-
-    def make_markdown(
-        self, header_kind: str, lang: NaturalLanguage, n_sample: int, numbering: bool
-    ) -> str:
-        if not self.exists():
-            return ""
-
-        markdown_text = ""
-        with open(self.filename, "r") as f:
-            contents = f.read()
-            if header_kind == "input":
-                markdown_text += lang.header_input()
-            elif header_kind == "output":
-                markdown_text += lang.header_output()
-            if numbering:
-                markdown_text += f" {n_sample}"
-            markdown_text += "\n"
-            markdown_text += "<pre>\n" + contents + "</pre>\n"
-        return markdown_text
 
 
 class SamplesConverter:
@@ -148,20 +108,18 @@ class SamplesConverter:
     def print_warning(
         self,
         sample_name: str,
-        in_file: SampleFile,
-        out_file: SampleFile,
-        diff_file: SampleFile,
-        exp_file: SampleFile,
+        in_file: pathlib.Path,
+        out_file: pathlib.Path,
+        exp_file: pathlib.Path,
     ) -> None:
         # 入力 / 出力のいずれかが欠けている場合は警告だけにとどめる
-        out_exists = out_file.exists() or diff_file.exists()
-        if (not in_file.exists()) and (not out_exists):
+        if (not in_file.exists()) and (not out_file.exists()):
             logger.warning(f"{sample_name}: Neither input-file nor output-file exists.")
             logger.warning("Recognized as interactive sample.")
         elif not in_file.exists():
             logger.warning(f"{sample_name}: Input file does not exist.")
             logger.warning("Recognized as output-only sample.")
-        elif not out_exists:
+        elif not out_file.exists():
             logger.warning(f"{sample_name}: Output file does not exist.")
             logger.warning("Recognized as input-only sample.")
 
@@ -169,7 +127,9 @@ class SamplesConverter:
         if not exp_file.exists():
             logger.warning(f"{sample_name}: There is no explanation.")
 
-    def convert(self, samples: dict[str, Any], problem_attr: dict[str, Any]) -> None:
+    def convert(
+        self, samples: dict[str, Any], problem_attr: dict[str, Any], template: str
+    ) -> None:
         """
         - `sample_path` が指定されていない場合: 警告を出して抜ける
         - `sample_path` が指定されている場合
@@ -180,7 +140,6 @@ class SamplesConverter:
             logger.warning("samples are not set")
             return
 
-        language = NaturalLanguage(problem_attr["lang"])
         sample_names = self.get_sample_names_list(
             problem_attr["sample_path"],
             problem_attr["statement_path"],
@@ -190,48 +149,52 @@ class SamplesConverter:
         if len(sample_names) == 0:
             logger.warning("samples are not set")
 
-        numbering = len(sample_names) >= 2
+        env = Environment(
+            loader=DictLoader({"template": template}),
+        )
+        do_numbering = len(sample_names) >= 2
         sample_text_all = ""
-        for n_sample, sample_name in enumerate(sample_names, start=1):
-            logger.info(f"replace sample {n_sample} ({sample_name})")
+        for i_sample, sample_name in enumerate(sample_names, start=1):
+            logger.info(f"replace sample {i_sample} ({sample_name})")
 
-            in_file = SampleFile(
-                problem_attr["sample_path"] / pathlib.Path(f"{sample_name}.in")
+            input_file = pathlib.Path(problem_attr["sample_path"] / f"{sample_name}.in")
+            output_file = pathlib.Path(
+                problem_attr["sample_path"] / f"{sample_name}.out"
             )
-            out_file = SampleFile(
-                problem_attr["sample_path"] / pathlib.Path(f"{sample_name}.out")
+            if not output_file.exists():
+                output_file = pathlib.Path(
+                    problem_attr["sample_path"] / f"{sample_name}.diff"
+                )
+            md_file = pathlib.Path(problem_attr["sample_path"] / f"{sample_name}.md")
+            explanation_file = pathlib.Path(
+                problem_attr["sample_path"] / f"{problem_attr['lang']}/{sample_name}.md"
             )
-            diff_file = SampleFile(
-                problem_attr["sample_path"] / pathlib.Path(f"{sample_name}.diff")
-            )
-            md_file = SampleFile(
-                problem_attr["sample_path"] / pathlib.Path(f"{sample_name}.md")
-            )
-            exp_file = SampleFile(
-                problem_attr["sample_path"]
-                / pathlib.Path(f"{problem_attr['lang']}/{sample_name}.md")
-            )
-            self.print_warning(sample_name, in_file, out_file, diff_file, exp_file)
+            self.print_warning(sample_name, input_file, output_file, explanation_file)
 
-            name = "s" + str(n_sample)
-            sample_text = ""
-            sample_text += in_file.make_markdown("input", language, n_sample, numbering)
-            sample_text += out_file.make_markdown(
-                "output", language, n_sample, numbering
+            sample_data = {
+                "do_numbering": do_numbering,
+                "i_sample": i_sample,
+                "language": problem_attr["lang"],
+            }
+            if input_file.exists():
+                sample_data["input_text"] = fetch_text(input_file)
+            if output_file.exists():
+                sample_data["output_text"] = fetch_text(output_file)
+            if md_file.exists():
+                sample_data["md_text"] = fetch_text(md_file)
+            if explanation_file.exists():
+                sample_data["explanation_text"] = fetch_text(explanation_file)
+            sample_text = env.get_template("template").render(
+                sample_data=sample_data,
             )
-            sample_text += diff_file.make_markdown(
-                "output", language, n_sample, numbering
-            )
-            sample_text += md_file.print_raw()
-            sample_text += exp_file.print_raw()
-
-            samples[name] = sample_text
+            key = "s" + str(i_sample)
+            samples[key] = sample_text
             sample_text_all += sample_text
         samples["all"] = sample_text_all
 
 
 class VariablesConverter:
-    def __init__(self, problem_attr: dict[str, Any]) -> None:
+    def __init__(self, problem_attr: dict[str, Any], sample_template: str) -> None:
         self.vars = {}  # type: dict[str, Any]
         self.vars["constraints"] = {}  # dict[str, str]
         self.vars["samples"] = {}  # dict[str, str]
@@ -239,7 +202,9 @@ class VariablesConverter:
         self.samples_converter = SamplesConverter()
 
         self.constraints_converter.convert(self.vars["constraints"], problem_attr)
-        self.samples_converter.convert(self.vars["samples"], problem_attr)
+        self.samples_converter.convert(
+            self.vars["samples"], problem_attr, sample_template
+        )
 
     def __getitem__(self, key: str) -> dict[str, str]:
         if key not in self.vars:

--- a/statements_manager/template.py
+++ b/statements_manager/template.py
@@ -133,6 +133,26 @@ default_template_markdown = """
 {% endfor %}
 """
 
+default_sample_template_html = """
+{% if sample_data.input_text is defined %}
+    <h3>{% if sample_data.language == "ja" %}入力例{% elif sample_data.language == "en" %}Sample Input{% endif %} {% if sample_data.do_numbering %}{{ sample_data.i_sample }}{% endif %}</h3>
+    <pre>{{ sample_data.input_text }}</pre>
+{% endif %}
+
+{% if sample_data.output_text is defined %}
+    <h3>{% if sample_data.language == "ja" %}出力例{% elif sample_data.language == "en" %}Sample Output{% endif %} {% if sample_data.do_numbering %}{{ sample_data.i_sample }}{% endif %}</h3>
+    <pre>{{ sample_data.output_text }}</pre>
+{% endif %}
+
+{% if sample_data.md_text is defined %}
+{{ sample_data.md_text }}
+{% endif %}
+
+{% if sample_data.explanation_text is defined %}
+{{ sample_data.explanation_text }}
+{% endif %}
+"""
+
 template_pdf_options = {
     "encoding": "UTF-8",
     "page-size": "A4",


### PR DESCRIPTION
サンプル入出力の形式をテンプレートで自由に設定可能にした。使える変数は以下の通り

- `language`: 自然言語の種類
  - 日本語なら「入力例」「出力例」を、英語なら "Sample Input" "Sample Output" を出したいため
- `do_numbering`: ナンバリングを行うかどうか
  - サンプルが 1 個以下の場合は `false`、それ以外で `true`
- `i_sample`: 何番目のサンプルであるかを表す整数
- `input_text`: 入力ファイルに対応するテキスト
- `output_text`: 出力ファイルに対応するテキスト
- `md_text`: Markdown ファイルに対応するテキスト (インタラクティブを想定) 
- `explanation_text`: 説明ファイルに対応するテキスト (入出力例の説明を想定)

ref: #103