### PR TITLE
force-dump オプションの追加

### DIFF
--- a/statements_manager/main.py
+++ b/statements_manager/main.py
@@ -67,6 +67,12 @@ def get_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="make problemset file",
     )
+    subparser.add_argument(
+        "-f",
+        "--force-dump",
+        action="store_true",
+        help="always dump output file",
+    )
 
     subparser = subparsers.add_parser(
         "reg-creds",
@@ -86,12 +92,13 @@ def subcommand_run(
     working_dir: str,
     output: str,
     make_problemset: bool,
+    force_dump: bool,
 ) -> None:
     working_dir = str(pathlib.Path(working_dir).resolve())
     logger.debug(f"run: working_dir = '{working_dir}'")
     project = Project(working_dir, output)  # Project
 
-    project.run_problems(make_problemset)
+    project.run_problems(make_problemset, force_dump)
     logger.debug("run command ended successfully.")
 
 
@@ -137,6 +144,7 @@ def main() -> None:
             working_dir=args.working_dir,
             output=args.output,
             make_problemset=args.make_problemset,
+            force_dump=args.force_dump,
         )
     elif args.subcommand == "reg-creds":
         subcommand_reg_creds(

--- a/statements_manager/src/manager.py
+++ b/statements_manager/src/manager.py
@@ -193,6 +193,7 @@ class Manager:
         output_ext: str,
         problem_ids: List[str],
         is_problemset: bool,
+        force_dump: bool,
         cache: dict[str, Any],
         reference_cache: dict[str, Any],
     ) -> dict[str, Any]:
@@ -208,7 +209,7 @@ class Manager:
                 is_problemset=is_problemset,
             )
             cache["contents"] = hashlib.sha256(html.encode()).hexdigest()
-            if cache != reference_cache:
+            if cache != reference_cache or force_dump:
                 self.save_file(html, output_path)
             else:
                 logger.warning("skip dumping html: same result as before")
@@ -221,7 +222,7 @@ class Manager:
                 pdf_path=output_path,
             )
             cache["contents"] = hashlib.sha256(html.encode()).hexdigest()
-            if cache != reference_cache:
+            if cache != reference_cache or force_dump:
                 wait_second = int(cast(int, pdf_attr["javascript-delay"]))
                 if wait_second > 0:
                     logger.info(f"please wait... ({wait_second} [msec] or greater)")
@@ -235,7 +236,7 @@ class Manager:
                 is_problemset=is_problemset,
             )
             cache["contents"] = hashlib.sha256(md.encode()).hexdigest()
-            if cache != reference_cache:
+            if cache != reference_cache or force_dump:
                 self.save_file(md, output_path)
             else:
                 logger.warning("skip dumping md: same result as before")
@@ -249,6 +250,7 @@ class Manager:
         problem_ids: List[str],
         output_ext: str,
         make_problemset: bool,
+        force_dump: bool,
     ) -> None:
         # 問題文を取ってきて変換
         valid_problem_ids = []
@@ -292,6 +294,7 @@ class Manager:
                 output_ext=output_ext,
                 problem_ids=[problem_id],
                 is_problemset=False,
+                force_dump=force_dump,
                 cache=problem_cache,
                 reference_cache=reference_cache[output_ext][problem_id],
             )
@@ -333,6 +336,7 @@ class Manager:
                 output_ext=output_ext,
                 problem_ids=valid_problem_ids,
                 is_problemset=True,
+                force_dump=force_dump,
                 cache=problemset_cache,
                 reference_cache=reference_problemset_cache[output_ext],
             )

--- a/statements_manager/src/project.py
+++ b/statements_manager/src/project.py
@@ -29,13 +29,14 @@ class Project:
             pdf_attr_raw=self.pdf_attr_raw,
         )
 
-    def run_problems(self, make_problemset: bool) -> None:
+    def run_problems(self, make_problemset: bool, force_dump: bool) -> None:
         """問題文作成を実行する"""
         problem_ids: list[str] = sorted(list(self.problem_attr.keys()))
         self.stmts_manager.run(
             problem_ids=problem_ids,
             output_ext=self._ext,
             make_problemset=make_problemset,
+            force_dump=force_dump,
         )
 
     def _check_project(self) -> None:


### PR DESCRIPTION
`--force-dump` または `-f` で、キャッシュを無視して強制的に上書きする