### PR TITLE
conf.py の不具合を修正

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,9 +26,9 @@ else:
     tag = 'v{}'.format(__version__)
 
 extlinks = {
-    'github': ('https://github.com/%s', ''),
-    'blob': (f'https://github.com/tsutaj/statements-manager/blob/{tag}/%s', ''),
-    'tree': (f'https://github.com/tsutaj/statements-manager/tree/{tag}/%s', ''),
+    'github': ('https://github.com/%s', '%s'),
+    'blob': (f'https://github.com/tsutaj/statements-manager/blob/{tag}/%s', '%s'),
+    'tree': (f'https://github.com/tsutaj/statements-manager/tree/{tag}/%s', '%s'),
 }
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
- Sphinx のバージョンが上がったことで Read the Docs 上でビルドができなくなってしまったので調査
- extlinks の設定が誤っていたので修正
  - 第 1 引数でフォーマット文字列 `%s` を使っている場合、第 2 引数でもフォーマット文字列を含まなければならない
  - リファレンス: https://www.sphinx-doc.org/ja/master/usage/extensions/extlinks.html
  - 参考 (同じ悩みを抱えている人がいた): https://github.com/sphinx-doc/sphinx/issues/11132
