### PR TITLE
sample markdown, explanation のレンダリング時のバグ修正

### DIFF
--- a/statements_manager/src/variables_converter.py
+++ b/statements_manager/src/variables_converter.py
@@ -7,6 +7,7 @@ from logging import Logger, getLogger
 from typing import Any, Set
 
 from jinja2 import DictLoader, Environment
+from markdown import markdown
 
 logger: Logger = getLogger(__name__)
 
@@ -183,9 +184,27 @@ class SamplesConverter:
             if output_file.exists():
                 sample_data["output_text"] = fetch_text(output_file)
             if md_file.exists():
-                sample_data["md_text"] = fetch_text(md_file)
+                md_text = fetch_text(md_file)
+                md_text = markdown(
+                    md_text,
+                    extensions=[
+                        "md_in_html",
+                        "tables",
+                        "fenced_code",
+                    ],
+                )
+                sample_data["md_text"] = md_text
             if explanation_file.exists():
-                sample_data["explanation_text"] = fetch_text(explanation_file)
+                explanation_text = fetch_text(explanation_file)
+                explanation_text = markdown(
+                    explanation_text,
+                    extensions=[
+                        "md_in_html",
+                        "tables",
+                        "fenced_code",
+                    ],
+                )
+                sample_data["explanation_text"] = explanation_text
             sample_text = env.get_template("template").render(
                 sample_data=sample_data,
             )


### PR DESCRIPTION
- sample markdown および sample explanation で Markdown 記法を使っても、レンダリング時に反映されないバグがあったので修正
  - sample の置換を、問題文のレンダリングの後に持っていってしまったために起こったバグだった ([ここの変更](https://github.com/tsutaj/statements-manager/commit/47300d51f2ec0f7682d512eed35f79efd8845fbb#diff-0b9dc88156d87f8214a9352976ecb7eb69e10a51e059592983c7982cbcba4cf0L230)で発生している)
  - sample markdown および sample explanation に関して個別にレンダリングすることで解決