### PR TITLE
Prevent converting Markdown to HTML for md mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,13 +132,11 @@ dmypy.json
 credentials.json
 token.pickle
 *~
-#*
+\#*
 output/
 batch.sh
 run.sh
 ss-out/
 constraints.hpp
 virtualenv/
-problemset.html
-problemset.md
-problemset.pdf
+problemset/

--- a/sample/templates/sample_default.html
+++ b/sample/templates/sample_default.html
@@ -1,11 +1,13 @@
 {% if sample_data.input_text is defined %}
-    <h3>{% if sample_data.language == "ja" %}入力例{% elif sample_data.language == "en" %}Sample Input{% endif %} {% if sample_data.do_numbering %}{{ sample_data.i_sample }}{% endif %}</h3>
-    <pre>{{ sample_data.input_text }}</pre>
+### {% if sample_data.language == "ja" %}入力例{% elif sample_data.language == "en" %}Sample Input{% endif %} {% if sample_data.do_numbering %}{{ sample_data.i_sample }}{% endif %}
+```
+{{ sample_data.input_text }}```
 {% endif %}
 
 {% if sample_data.output_text is defined %}
-    <h3>{% if sample_data.language == "ja" %}出力例{% elif sample_data.language == "en" %}Sample Output{% endif %} {% if sample_data.do_numbering %}{{ sample_data.i_sample }}{% endif %}</h3>
-    <pre>{{ sample_data.output_text }}</pre>
+## {% if sample_data.language == "ja" %}出力例{% elif sample_data.language == "en" %}Sample Output{% endif %} {% if sample_data.do_numbering %}{{ sample_data.i_sample }}{% endif %}
+```
+{{ sample_data.output_text }}```
 {% endif %}
 
 {% if sample_data.md_text is defined %}

--- a/statements_manager/src/renderer.py
+++ b/statements_manager/src/renderer.py
@@ -156,17 +156,17 @@ class Renderer:
                 contents = problem_attr[problem_id]["raw_statement"]
                 contents = self.apply_preprocess(contents)
 
+                rendered_contents = self.replace_vars(
+                    problem_attr[problem_id], contents
+                )
                 rendered_contents = markdown(
-                    contents,
+                    rendered_contents,
                     extensions=[
                         self.replace_sample_format,
                         "md_in_html",
                         "tables",
                         "fenced_code",
                     ],
-                )
-                rendered_contents = self.replace_vars(
-                    problem_attr[problem_id], rendered_contents
                 )
                 problem_attr[problem_id]["statement"] = rendered_contents
 

--- a/statements_manager/src/variables_converter.py
+++ b/statements_manager/src/variables_converter.py
@@ -7,7 +7,6 @@ from logging import Logger, getLogger
 from typing import Any, Set
 
 from jinja2 import DictLoader, Environment
-from markdown import markdown
 
 logger: Logger = getLogger(__name__)
 
@@ -185,25 +184,9 @@ class SamplesConverter:
                 sample_data["output_text"] = fetch_text(output_file)
             if md_file.exists():
                 md_text = fetch_text(md_file)
-                md_text = markdown(
-                    md_text,
-                    extensions=[
-                        "md_in_html",
-                        "tables",
-                        "fenced_code",
-                    ],
-                )
                 sample_data["md_text"] = md_text
             if explanation_file.exists():
                 explanation_text = fetch_text(explanation_file)
-                explanation_text = markdown(
-                    explanation_text,
-                    extensions=[
-                        "md_in_html",
-                        "tables",
-                        "fenced_code",
-                    ],
-                )
                 sample_data["explanation_text"] = explanation_text
             sample_text = env.get_template("template").render(
                 sample_data=sample_data,

--- a/statements_manager/template.py
+++ b/statements_manager/template.py
@@ -135,13 +135,15 @@ default_template_markdown = """
 
 default_sample_template_html = """
 {% if sample_data.input_text is defined %}
-    <h3>{% if sample_data.language == "ja" %}入力例{% elif sample_data.language == "en" %}Sample Input{% endif %} {% if sample_data.do_numbering %}{{ sample_data.i_sample }}{% endif %}</h3>
-    <pre>{{ sample_data.input_text }}</pre>
+### {% if sample_data.language == "ja" %}入力例{% elif sample_data.language == "en" %}Sample Input{% endif %} {% if sample_data.do_numbering %}{{ sample_data.i_sample }}{% endif %}
+```
+{{ sample_data.input_text }}```
 {% endif %}
 
 {% if sample_data.output_text is defined %}
-    <h3>{% if sample_data.language == "ja" %}出力例{% elif sample_data.language == "en" %}Sample Output{% endif %} {% if sample_data.do_numbering %}{{ sample_data.i_sample }}{% endif %}</h3>
-    <pre>{{ sample_data.output_text }}</pre>
+## {% if sample_data.language == "ja" %}出力例{% elif sample_data.language == "en" %}Sample Output{% endif %} {% if sample_data.do_numbering %}{{ sample_data.i_sample }}{% endif %}
+```
+{{ sample_data.output_text }}```
 {% endif %}
 
 {% if sample_data.md_text is defined %}


### PR DESCRIPTION
Closes #129 

Markdown 形式の解説文などが Markdown mode のときに HTML 化してしまう問題の修正