### PR TITLE
Load parent problemset file

### DIFF
--- a/statements_manager/main.py
+++ b/statements_manager/main.py
@@ -104,7 +104,7 @@ def subcommand_run(
 ) -> None:
     working_dir = str(pathlib.Path(working_dir).resolve())
     logger.debug(f"run: working_dir = '{working_dir}'")
-    project = Project(working_dir, output)  # Project
+    project = Project(working_dir, output, make_problemset)
 
     project.run_problems(make_problemset, force_dump, constraints_only)
     logger.debug("run command ended successfully.")

--- a/statements_manager/src/execute_config.py
+++ b/statements_manager/src/execute_config.py
@@ -12,7 +12,7 @@ from statements_manager.src.statement_location_mode import (
     is_valid_url,
     recognize_mode,
 )
-from statements_manager.src.utils import read_text_file, resolve_path
+from statements_manager.src.utils import read_text_file, resolve_path, to_path
 from statements_manager.template import (
     default_sample_template_html,
     default_template_html,
@@ -184,10 +184,10 @@ class ProblemSetConfig(AttributeConstraints):
         dirname = problemset_filename.parent.resolve()
         self.output_path = dirname / "problemset"
         self.template_html: str = read_text_file(
-            self.template.template_path, default_template_html
+            to_path(self.template.template_path), default_template_html
         )
         self.sample_template_html: str = read_text_file(
-            self.template.sample_template_path, default_sample_template_html
+            to_path(self.template.sample_template_path), default_sample_template_html
         )
 
     def get_problem(self, id: str) -> ProblemConfig:

--- a/statements_manager/src/project.py
+++ b/statements_manager/src/project.py
@@ -6,16 +6,16 @@ from pathlib import Path
 from statements_manager.src.convert_task_runner import ConvertTaskRunner
 from statements_manager.src.execute_config import ProblemSetConfig
 from statements_manager.src.output_file_kind import OutputFileKind
-from statements_manager.src.utils import read_toml_file
+from statements_manager.src.utils import read_toml_file, find_in_parents
 
 logger: Logger = getLogger(__name__)
 
 
 class Project:
-    def __init__(self, working_dir: str, ext: str) -> None:
+    def __init__(self, working_dir: str, ext: str, make_problemset: bool) -> None:
         self._cwd: Path = Path(working_dir).resolve()
         self._ext: OutputFileKind = OutputFileKind(ext)
-        self.problemset_config = self._fetch_problemset_config()
+        self.problemset_config = self._fetch_problemset_config(make_problemset)
         self.task_runner = ConvertTaskRunner(
             problemset_config=self.problemset_config,
         )
@@ -33,17 +33,30 @@ class Project:
             constraints_only=constraints_only,
         )
 
-    def _fetch_problemset_config(
-        self,
-    ) -> ProblemSetConfig:
+    def _fetch_problemset_config(self, make_problemset: bool) -> ProblemSetConfig:
         """problem.toml が含まれているディレクトリを問題ディレクトリとみなす
         問題ごとに設定ファイルを読み込む
         """
-        problemset_config_filename = self._cwd / "problemset.toml"
+        default_filename = self._cwd / "problemset.toml"
+        problemset_config_filename = find_in_parents(default_filename)
+        if problemset_config_filename is None:
+            problemset_config_filename = default_filename
+            if make_problemset:
+                logger.warn("problemset.toml not found.")
+                logger.warn(
+                    "You can change the design of the problem set. "
+                    + "see the document: https://statements-manager.readthedocs.io/ja/stable/problemset_config.html"
+                )
+        logger.debug(f"path to problemset: {problemset_config_filename}")
         problemset_config_dict = read_toml_file(problemset_config_filename)
         problemset_config = ProblemSetConfig(
             problemset_config_filename, problemset_config_dict
         )
-        for problem_file in sorted(self._cwd.glob("./**/problem.toml")):
+
+        # if make_problemset, try to read all problems.
+        problem_dir = (
+            problemset_config_filename.parent if make_problemset else self._cwd
+        )
+        for problem_file in sorted(problem_dir.glob("./**/problem.toml")):
             problemset_config.add_problem_configs(problem_file)
         return problemset_config

--- a/statements_manager/src/project.py
+++ b/statements_manager/src/project.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from statements_manager.src.convert_task_runner import ConvertTaskRunner
 from statements_manager.src.execute_config import ProblemSetConfig
 from statements_manager.src.output_file_kind import OutputFileKind
-from statements_manager.src.utils import read_toml_file, find_in_parents
+from statements_manager.src.utils import find_in_parents, read_toml_file
 
 logger: Logger = getLogger(__name__)
 
@@ -45,7 +45,7 @@ class Project:
                 logger.warn("problemset.toml not found.")
                 logger.warn(
                     "You can change the design of the problem set. "
-                    + "see the document: https://statements-manager.readthedocs.io/ja/stable/problemset_config.html"
+                    + "see the document: https://statements-manager.readthedocs.io/ja/stable/problemset_config.html"  # noqa
                 )
         logger.debug(f"path to problemset: {problemset_config_filename}")
         problemset_config_dict = read_toml_file(problemset_config_filename)

--- a/statements_manager/src/utils.py
+++ b/statements_manager/src/utils.py
@@ -9,16 +9,31 @@ from google.auth.transport.requests import Request
 from google_auth_oauthlib.flow import InstalledAppFlow
 
 
+def to_path(path: str | None) -> Path | None:
+    return Path(path) if path is not None else None
+
+
+def find_in_parents(path: Path) -> Path | None:
+    path = path.resolve()
+    dir, filename = path.parent, path.name
+    while not path.exists():
+        if dir.parent == dir:
+            return None
+        dir = dir.parent
+        path = dir / filename
+    return path
+
+
 def read_toml_file(path: Path | None) -> dict:
     if path is None or not path.exists():
         return {}
     return toml.load(path)
 
 
-def read_text_file(path: str | Path | None, default: str) -> str:
-    if path is None or not Path(path).exists():
+def read_text_file(path: Path | None, default: str) -> str:
+    if path is None or not path.exists():
         return default
-    with open(path) as f:
+    with path.open() as f:
         return f.read()
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,26 @@
+import pytest
+
+from statements_manager.src.utils import find_in_parents
+
+
+def test_find_in_parents(tmp_path):
+    """
+    tmp_path --- sub1 --- sub2 --- sub3
+              |        |
+              |        -- filename
+              |
+              -- sub4
+    """
+    dir_sub1 = tmp_path / "sub1"
+    dir_sub2sub3 = dir_sub1 / "sub2" / "sub3"
+    dir_sub2sub3.mkdir(parents=True)
+    dir_sub4 = tmp_path / "sub4"
+    dir_sub4.mkdir(parents=True)
+    file = dir_sub1 / "filename"
+    file.touch()
+    assert find_in_parents(tmp_path / "sub1" / "filename") == file
+    assert find_in_parents(tmp_path / "sub1" / "sub2" / "filename") == file
+    assert find_in_parents(tmp_path / "sub1" / "sub2" / "sub3" / "filename") == file
+    assert find_in_parents(tmp_path / "filename") is None
+    assert find_in_parents(tmp_path / "sub4" / "filename") is None
+    assert find_in_parents(tmp_path / "sub5" / "filename") is None


### PR DESCRIPTION
Resolves #149 

親の `problemset.toml` を読み込むようにしました。

## 細かい挙動について

- `ss-manager` と実行したときは、ターゲットディレクトリの子孫にある問題がすべてレンダリングされます。
- `ss-manager -p` と実行したときは、 `problemset.toml` が存在するディレクトリの子孫にある問題がすべてレンダリングされます。
  - `problemset.toml` が見つからない場合は、 `-p` をつけない場合と同じ挙動になります。
