### PR TITLE
Update minimum Python version from 3.8 to 3.9.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.9, 3.10]
+        python-version: ["3.9", "3.10"]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Python 3.9.2
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9.2
+          python-version: "3.9.2"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.9.2, 3.10]
+        python-version: [3.9, 3.10]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -23,6 +23,28 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          pip3 install --upgrade setuptools
+          pip3 install .[dev]
+
+      - name: Run tests
+        run: |
+          ss-manager -h
+          pytest -v
+        shell: bash
+
+  test-python-3-9-2:
+    runs-on: ubuntu-20.04
+    
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python 3.9.2
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9.2
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.8, 3.9]
+        python-version: [3.9.2, 3.10]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,16 +35,16 @@ jobs:
           pytest -v
         shell: bash
 
-  test-python-3-9-2:
-    runs-on: ubuntu-20.04
+  test-python-3-9-12:
+    runs-on: ubuntu-24.04
     
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python 3.9.2
+      - name: Set up Python 3.9.12
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9.2"
+          python-version: "3.9.12"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,8 @@ jobs:
         shell: bash
 
   test-python-3-9-12:
-    runs-on: ubuntu-24.04
-    
+    runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v3
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@
 
 このガイドでは、Python で書かれたパッケージに対して初めてコミットする方向けに、開発手法のうちのひとつを説明しています。既に何らかの開発手法について理解されている方は、この節を読む必要はありません。
 
-### 1. Python (>= 3.8) をインストールする
+### 1. Python (>= 3.9.2) をインストールする
 
 [Python 公式ページ](https://www.python.org/downloads/) を参照してください。リンク先のページを見てもよくわからない場合は、お使いの OS をキーワードにして検索すると良いでしょう。(例えば Windows を使用している場合、["Python3 Windows インストール方法"](https://www.google.com/search?channel=fs&client=ubuntu&q=Python3+Windows+%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB%E6%96%B9%E6%B3%95) で検索する、など)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@
 
 このガイドでは、Python で書かれたパッケージに対して初めてコミットする方向けに、開発手法のうちのひとつを説明しています。既に何らかの開発手法について理解されている方は、この節を読む必要はありません。
 
-### 1. Python (>= 3.9.2) をインストールする
+### 1. Python (>= 3.9.12) をインストールする
 
 [Python 公式ページ](https://www.python.org/downloads/) を参照してください。リンク先のページを見てもよくわからない場合は、お使いの OS をキーワードにして検索すると良いでしょう。(例えば Windows を使用している場合、["Python3 Windows インストール方法"](https://www.google.com/search?channel=fs&client=ubuntu&q=Python3+Windows+%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB%E6%96%B9%E6%B3%95) で検索する、など)
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -54,7 +54,7 @@ GitHub Actions などの CI サービスと併用することで、リポジト�
         - name: Set up Python 3
             uses: actions/setup-python@v2
             with:
-            python-version: 3.9.2
+            python-version: 3.9
         - name: Install dependencies
             run: |
             python -m pip install --upgrade pip

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -54,7 +54,7 @@ GitHub Actions などの CI サービスと併用することで、リポジト�
         - name: Set up Python 3
             uses: actions/setup-python@v2
             with:
-            python-version: 3.8
+            python-version: 3.9.2
         - name: Install dependencies
             run: |
             python -m pip install --upgrade pip

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ classifiers =
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
-    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Topic :: Internet :: WWW/HTTP
     Topic :: Software Development
     Topic :: Utilities

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     url="https://github.com/tsutaj/statements-manager",
     license="Apache License 2.0",
     description="",
-    python_requires=">=3.8",
+    python_requires=">=3.9.2",
     install_requires=[
         "google-api-python-client",
         "google-auth-httplib2",

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     url="https://github.com/tsutaj/statements-manager",
     license="Apache License 2.0",
     description="",
-    python_requires=">=3.9.2",
+    python_requires=">=3.9.12",
     install_requires=[
         "google-api-python-client",
         "google-auth-httplib2",


### PR DESCRIPTION
- issue #175 で指摘されているように、Python 3.9.2 未満では PDF 生成時にエラーが発生する
- CI では 3.9.12 以上でないとチェックできない

このため、最小要件バージョンを 3.9.12 に引き上げました。

以下の変更を行いました：
- `setup.py` の `python_requires` を `>=3.9.12` に変更
- `setup.cfg` のクラシファイアを Python 3.9 に更新
- GitHub Workflows の `test.yml` でテストする Python バージョンを変更

 ---
*Generated by Claude through Cursor AI Assistant*