### PR TITLE
Use python3 as default command for preprocess/postprocess

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -57,7 +57,7 @@ GitHub Actions などの CI サービスと併用することで、リポジト�
             python-version: 3.9
         - name: Install dependencies
             run: |
-            python -m pip install --upgrade pip
+            python3 -m pip install --upgrade pip
             pip install statements-manager
         - name: Run statements-manager
             run: |

--- a/docs/problemset_config.rst
+++ b/docs/problemset_config.rst
@@ -45,7 +45,7 @@ problemset.toml の書き方
 
     .. problemsettoml:: preprocess_command
         
-        preprocess_path で指定されたスクリプトを実行するためのコマンドを指定します。デフォルトは ``python`` です。Python 以外のスクリプトを使用する場合や、``python3`` コマンドを使用したい場合などに指定してください。
+        preprocess_path で指定されたスクリプトを実行するためのコマンドを指定します。デフォルトは ``python3`` です。Python 以外のスクリプトを使用する場合や、``python3`` コマンドを使用したい場合などに指定してください。
     
     .. problemsettoml:: postprocess_path
         
@@ -55,7 +55,7 @@ problemset.toml の書き方
 
     .. problemsettoml:: postprocess_command
         
-        postprocess_path で指定されたスクリプトを実行するためのコマンドを指定します。デフォルトは ``python`` です。Python 以外のスクリプトを使用する場合や、``python3`` コマンドを使用したい場合などに指定してください。
+        postprocess_path で指定されたスクリプトを実行するためのコマンドを指定します。デフォルトは ``python3`` です。Python 以外のスクリプトを使用する場合や、``python3`` コマンドを使用したい場合などに指定してください。
 
 .. problemsettoml:: [pdf]
 

--- a/statements_manager/src/execute_config.py
+++ b/statements_manager/src/execute_config.py
@@ -107,10 +107,10 @@ class TemplatePathConfig(AttributeConstraints):
             filename, config, "postprocess_path", None
         )
         self.preprocess_command: str = self.optional(
-            filename, config, "preprocess_command", "python"
+            filename, config, "preprocess_command", "python3"
         )
         self.postprocess_command: str = self.optional(
-            filename, config, "postprocess_command", "python"
+            filename, config, "postprocess_command", "python3"
         )
 
         dirname = filename.parent.resolve()

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -142,7 +142,7 @@ def execute_and_verify_match(create_tempdir: str, extension: str):
 
         result = subprocess.run(
             [
-                "python",
+                "python3",
                 "statements_manager/main.py",
                 "run",
                 "-o",


### PR DESCRIPTION
Resolves #185 

python のデフォルト実行コマンドを `python` から `python3` に変更しました。
- `execute_config.py` のデフォルト値
- e2eテストのコマンド呼び出し
- ドキュメント

---
*Generated by Claude through Cursor AI Assistant*