### PR TITLE
Migrate license classifier to SPDX format (Apache-2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@
 Sorry, currently Japanese only :bow:
 
 https://statements-manager.readthedocs.io/
+
+## License
+
+- Apache-2.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,7 @@ __year__ = datetime.date.today().year
 project = "statements-manager"
 copyright = f"{__year__}, tsutaj"
 author = "tsutaj"
+license = "Apache-2.0"
 release = f"v{__version__}"
 
 rtd_version = os.environ.get('READTHEDOCS_VERSION')

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,12 +5,12 @@ classifiers =
     Development Status :: 4 - Beta
     Environment :: Console
     Intended Audience :: Developers
-    License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
     Programming Language :: Python :: 3.9
     Topic :: Internet :: WWW/HTTP
     Topic :: Software Development
     Topic :: Utilities
+license = Apache-2.0
 
 [options.extras_require]
 dev =

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     author="Yuya Sugie",
     author_email="y.sugie.15739d@gmail.com",
     url="https://github.com/tsutaj/statements-manager",
-    license="Apache License 2.0",
+    license="Apache-2.0",
     description="",
     python_requires=">=3.9.12",
     install_requires=[


### PR DESCRIPTION
Resolves #187 

- setup.cfg, setup.py, README, docs/conf.py のライセンス表記を SPDX 形式（Apache-2.0）に統一しました。
- 非推奨の license classifier を削除しました。

---
*Generated by Claude through Cursor AI Assistant*