### PR TITLE
Migrate PyPI publish workflow to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   pypi:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
 
     steps:
       - uses: actions/checkout@v1
@@ -32,7 +34,4 @@ jobs:
         run: python3 -m build
 
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Resolves #189
- pypa/gh-action-pypi-publish@master の利用を廃止し、@release/v1 へ変更
- APIトークンやusername/passwordを一切使わないTrusted Publishing（OIDC）方式に移行
- permissions: id-token: write を追加
- linterエラーの解消

---
*Generated by Claude through Cursor AI Assistant*