### PR TITLE
Rename template_html and sample_template_html variables

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,6 @@
   "python.formatting.provider": "black",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.organizeImports": true
+    "source.organizeImports": "explicit"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,6 @@
   "python.formatting.provider": "black",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.organizeImports": "explicit"
+    "source.organizeImports": true
   }
 }

--- a/statements_manager/src/convert_task_runner.py
+++ b/statements_manager/src/convert_task_runner.py
@@ -31,8 +31,8 @@ class ConvertTaskRunner:
         self._cwd = Path.cwd()
         self.problemset_config = problemset_config
         self.renderer = Renderer(
-            problemset_config.template_html,
-            problemset_config.sample_template_html,
+            problemset_config.template_content,
+            problemset_config.sample_template_content,
             problemset_config.template.preprocess_path,
             problemset_config.template.postprocess_path,
             problemset_config.template.preprocess_command,

--- a/statements_manager/src/execute_config.py
+++ b/statements_manager/src/execute_config.py
@@ -14,8 +14,8 @@ from statements_manager.src.statement_location_mode import (
 )
 from statements_manager.src.utils import read_text_file, resolve_path, to_path
 from statements_manager.template import (
-    default_sample_template_html,
-    default_template_html,
+    default_sample_template,
+    default_template,
     template_pdf_options,
 )
 
@@ -199,12 +199,12 @@ class ProblemSetConfig(AttributeConstraints):
 
         dirname = problemset_filename.parent.resolve()
         self.output_path = dirname / "problemset"
-        self.template_html: str = read_text_file(
-            to_path(self.template.template_path), default_template_html, self.encoding
+        self.template_content: str = read_text_file(
+            to_path(self.template.template_path), default_template, self.encoding
         )
-        self.sample_template_html: str = read_text_file(
+        self.sample_template_content: str = read_text_file(
             to_path(self.template.sample_template_path),
-            default_sample_template_html,
+            default_sample_template,
             self.encoding,
         )
 

--- a/statements_manager/src/renderer.py
+++ b/statements_manager/src/renderer.py
@@ -47,15 +47,15 @@ class ReplaceSampleFormatExprExtension(Extension):
 class Renderer:
     def __init__(
         self,
-        template_html: str,
-        sample_template_html: str,
+        template_content: str,
+        sample_template_content: str,
         preprocess_path: Union[str, None],
         postprocess_path: Union[str, None],
         preprocess_command: str,
         postprocess_command: str,
     ):
-        self.template_html = template_html
-        self.sample_template_html = sample_template_html
+        self.template_content = template_content
+        self.sample_template_content = sample_template_content
         self.preprocess_path = preprocess_path
         self.postprocess_path = postprocess_path
         self.preprocess_command = preprocess_command
@@ -69,7 +69,7 @@ class Renderer:
             logger.error("statement_str is None")
             raise RuntimeError("statement_str is None")
         vars_manager = VariablesConverter(
-            problem_config, self.sample_template_html, encoding
+            problem_config, self.sample_template_content, encoding
         )
         env = Environment(
             variable_start_string="{@",
@@ -214,7 +214,7 @@ class Renderer:
         html = self.apply_template(
             problemset_config=problemset_config,
             problem_ids=problem_ids,
-            template=self.template_html,
+            template=self.template_content,
             is_problemset=is_problemset,
         )
         html = self.apply_postprocess(html)
@@ -295,7 +295,7 @@ class Renderer:
         result = self.apply_template(
             problemset_config=problemset_config,
             problem_ids=problem_ids,
-            template=self.template_html,
+            template=self.template_content,
             is_problemset=is_problemset,
         )
         result = self.apply_postprocess(result)

--- a/statements_manager/template.py
+++ b/statements_manager/template.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-default_template_html = """
+default_template = """
 <!DOCTYPE html>
 <html lang="ja">
 
@@ -133,7 +133,7 @@ default_template_markdown = """
 {% endfor %}
 """
 
-default_sample_template_html = """
+default_sample_template = """
 {% if sample_data.input_text is defined %}
 ### {% if sample_data.language == "ja" %}入力例{% elif sample_data.language == "en" %}Sample Input{% endif %} {% if sample_data.do_numbering %}{{ sample_data.i_sample }}{% endif %}
 ```


### PR DESCRIPTION
Rename `template_html` and `sample_template_html` variables to reflect their non-HTML content.

Variables previously suffixed with `_html` are now renamed to be more generic, as the content they hold is no longer exclusively HTML. `template_html` and `sample_template_html` were specifically renamed to `template_content` and `sample_template_content` respectively, to avoid name collisions with existing `template` attributes.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-4cc6cec1-3125-44a5-939b-deb6b6d1b042) · [Cursor](https://cursor.com/background-agent?bcId=bc-4cc6cec1-3125-44a5-939b-deb6b6d1b042)

[Slack Thread](https://tsutaj-playground.slack.com/archives/C02EUD46XS9/p1753095281815149?thread_ts=1753095281.815149&cid=C02EUD46XS9)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)