### PR TITLE
replace_assets_path に tex 用の正規表現を追加

### DIFF
--- a/statements_manager/src/renderer.py
+++ b/statements_manager/src/renderer.py
@@ -92,6 +92,11 @@ class Renderer:
                 f"\\1{problem_id}/\\2",
                 contents,
             )
+            contents = re.sub(
+                r"(\\includegraphics\s*(?:\[[^\]]*\])?\s*\{\s*(?:\./+)?assets/)",
+                rf"\1{problem_id}/",
+                contents,
+            )
         return contents
 
     def get_render_context(


### PR DESCRIPTION
tex ファイルに対し正しく置換されることを確認していますが、html, markdown ファイルに対し正しく置換されないことは確認していません（おそらく大丈夫なんじゃないかとは思っていますが）。

本当は actual_extension あたりを渡して分岐すべきな気もしますが、大工事になりそうなのとそうそう conflict することがなさそうなのでいったんこの状態にしてあります。
