### PR TITLE
Switch docs deployment from FTP to SSH (rsync): Part 1

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Deploy via rsync
         run: |
-          rsync -avz --delete \
+          rsync -avz --delete --itemize-changes \
             --exclude='.doctrees/' \
             --exclude='_sources/' \
             docs/_build/ \

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,8 +8,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 jobs:
   build-docs:
@@ -44,16 +42,16 @@ jobs:
           path: docs/_build
           retention-days: 7
 
-      - name: Deploy via FTP
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
+      - name: Setup SSH agent
+        uses: webfactory/ssh-agent@v0.9.0
         with:
-          server: ${{ secrets.FTP_HOST }}
-          username: ${{ secrets.FTP_USERNAME }}
-          password: ${{ secrets.FTP_PASSWORD }}
-          dry-run: false
-          local-dir: ./docs/_build/
-          server-dir: ./docs/statements-manager/
-          exclude: |
-            **/.venv/**
-            **/.doctrees/**
-            **/_sources/**
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-known-hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
+
+      - name: Deploy via rsync
+        run: |
+          rsync -avz --delete \
+            --exclude='.doctrees/' \
+            --exclude='_sources/' \
+            docs/_build/ \
+            ubuntu@${{ secrets.SSH_HOST }}:${{ secrets.SSH_DEPLOY_PATH }}/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Deploy via rsync
         run: |
-          rsync -avz --delete --itemize-changes \
+          rsync -avz --delete --itemize-changes --dry-run \
             --exclude='.doctrees/' \
             --exclude='_sources/' \
             docs/_build/ \


### PR DESCRIPTION
#245 

## 概要

ドキュメントのデプロイ方法を FTP から SSH (rsync) に切り替える。

## 変更内容

- `SamKirkland/FTP-Deploy-Action` を廃止し、`webfactory/ssh-agent` + `rsync` に移行
- 秘密鍵は `webfactory/ssh-agent` によりメモリ上の ssh-agent で管理し、ディスクへの書き出しを行わない（公開リポジトリ向けのセキュリティ対策）
- ホスト名・デプロイ先パスを GitHub Secrets で管理し、ワークフローファイルへの露出を防止
- `--delete` オプションにより、ビルドから削除されたファイルをサーバーからも除去
